### PR TITLE
Fix for an error in readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Welcome to the LangChain Crash Course repository! This repo contains all the cod
 5. Run the code examples:
 
    ```bash
-    python chat_models/1_chat_model_basic.py
+    python 1_chat_models/1_chat_model_basic.py
    ```
 
 ## Repository Structure


### PR DESCRIPTION
In installation section, the step 5 had wrong directory name.

   ```bash
    python chat_models/1_chat_model_basic.py
   ```
to
   ```bash
    python 1_chat_models/1_chat_model_basic.py
   ```