### PR TITLE
Encoding error in 1a_rag_basics.py

### DIFF
--- a/4_rag/1a_rag_basics.py
+++ b/4_rag/1a_rag_basics.py
@@ -21,7 +21,7 @@ if not os.path.exists(persistent_directory):
         )
 
     # Read the text content from the file
-    loader = TextLoader(file_path)
+    loader = TextLoader(file_path, encoding="utf-8")
     documents = loader.load()
 
     # Split the document into chunks

--- a/4_rag/2a_rag_basics_metadata.py
+++ b/4_rag/2a_rag_basics_metadata.py
@@ -31,7 +31,7 @@ if not os.path.exists(persistent_directory):
     documents = []
     for book_file in book_files:
         file_path = os.path.join(books_dir, book_file)
-        loader = TextLoader(file_path)
+        loader = TextLoader(file_path, encoding="utf-8")
         book_docs = loader.load()
         for doc in book_docs:
             # Add metadata to each document indicating its source


### PR DESCRIPTION
Added the encoding parameter for _TextLoader_ as 'utf-8' in '1a_rag_basics.py' because the system default encoding throws an error on my Windows system.